### PR TITLE
Fix of distance calculation

### DIFF
--- a/lib/operations/distance.ex
+++ b/lib/operations/distance.ex
@@ -12,7 +12,7 @@ defmodule LexorankEx.Oparations.Distance do
   defp reduce([{digit, index} | tail], acc) do
     case index do
       0 -> reduce(tail, acc + digit)
-      _ -> reduce(tail, acc + (digit * index * radix()))
+      _ -> reduce(tail, acc + (digit * radix() ** index))
     end
   end
 end

--- a/test/bucket_test.exs
+++ b/test/bucket_test.exs
@@ -70,6 +70,7 @@ defmodule Bucket.BucketTest do
   test "#distance/2" do
     assert Bucket.distance("1|V0000007", "1|V000000F") == 8
     assert Bucket.distance("2|00", "2|zz") == 3843
+    assert Bucket.distance("2|000", "2|zzz") == 238327
     assert Bucket.distance("3|aa", "3|bb") == 63
     assert Bucket.distance("1|00", "1|010") == 62
     assert Bucket.distance("1|a0", "1|b") == 62

--- a/test/lexorank_ex_test.exs
+++ b/test/lexorank_ex_test.exs
@@ -57,6 +57,7 @@ defmodule LexorankExTest do
   test "#distance/2" do
     assert LexorankEx.distance("V0000007", "V000000F") == 8
     assert LexorankEx.distance("00", "zz") == 3843
+    assert LexorankEx.distance("000", "zzz") == 238327
     assert LexorankEx.distance("aa", "bb") == 63
     assert LexorankEx.distance("00", "010") == 62
     assert LexorankEx.distance("a0", "b") == 62


### PR DESCRIPTION
Hello. First of all, thank you for the lib!
There is mistake in distance calculation.
Correct formula is `X = y(0) + y(1) * radix + y(2) * radix^2 … y(n) * size^(n-1)`
where “radix” is the base of the notation (in this case radix = 62) and y(n) — n-th number on the right.